### PR TITLE
Crossterm improvements

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -214,6 +214,7 @@ fn main() -> Result<()> {
     // set up tui using crossterm backend
     let stdout = io::stdout();
     crossterm::terminal::enable_raw_mode()?;
+    crossterm::execute!(io::stdout(), crossterm::terminal::EnterAlternateScreen)?;
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
     let mut stdout = io::stdout();
@@ -782,6 +783,7 @@ fn main() -> Result<()> {
     // clean up the terminal before exit
     terminal.clear().unwrap();
     crossterm::terminal::disable_raw_mode()?;
+    crossterm::execute!(io::stdout(), crossterm::terminal::LeaveAlternateScreen)?;
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -213,7 +213,7 @@ fn main() -> Result<()> {
 
     // set up tui using crossterm backend
     let stdout = io::stdout();
-    crossterm::terminal::enable_raw_mode().unwrap();
+    crossterm::terminal::enable_raw_mode()?;
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
     let mut stdout = io::stdout();
@@ -781,6 +781,8 @@ fn main() -> Result<()> {
 
     // clean up the terminal before exit
     terminal.clear().unwrap();
+    crossterm::terminal::disable_raw_mode()?;
+
     Ok(())
 }
 


### PR DESCRIPTION
Hey!
I recently tried `cns` and it works pretty well. But when I exit the interface I realized that my terminal buffer is not _flushed_ (my cursor was on the center) and I was not able to see what I was typing. So I dove into the code to see the issue and two things caught my eye:

1. Raw mode is not disabled on exit. 303c6ae fixes this issue.
2. Alternate screen is not used for the interface. With dca1bc8, `cns` enters/leaves the alternate screen on start/exit. 

More info: https://crossterm-rs.github.io/crossterm/docs/screen.html

